### PR TITLE
Fixing library folder config reader

### DIFF
--- a/keypirinha-steam/src/steam.py
+++ b/keypirinha-steam/src/steam.py
@@ -99,10 +99,10 @@ class Steam(kp.Plugin):
         try:
             with open(librarylist_path) as fp:
                 library_data = acf.load(fp)
-            for key, library_root in library_data['LibraryFolders'].items():
+            for key, library_root in library_data['libraryfolders'].items():
                 if not key.isdigit():
                     continue
-                extra_library = os.path.join(library_root, 'steamapps')
+                extra_library = os.path.join(library_root['path'], 'steamapps')
                 library_list.append(extra_library)
         except Exception as e:
             self.warn('Failed to extract extra library paths: {}'.format(e))


### PR DESCRIPTION
After a bit of searching it seems that the format of `libraryfolders.vdf` changed after the Steam Client update released on June 7th ([release notes](https://store.steampowered.com/oldnews/85088)). 

The issue was encountered by `protontricks` users on June 12th ([issue #108](https://github.com/Matoking/protontricks/issues/108)), but it had been fixed on June 6th, and released on June 9th.

The following are snippets of the library file format, before and after the breaking release.

**Release: 2021-05-17**
```
"LibraryFolders"
{
	"TimeNextStatsReport"		"1558451506"
	"ContentStatsID"		"7825075166457755736"
	"1"		"D:\\Steam"
}
```

**Release: 2021-06-07**
```
"libraryfolders"
{
	"contentstatsid"		"-5740639267058770728"
	"1"
	{
		"path"		"D:\\Steam"
		"label"		""
		"contentid"		"8152063291376049057"
		"totalsize"		"512108785664"
		"apps"
		{
		}
	}
}
```

Here is a patch, if you want to apply the fix manually.

```patch
diff --git a/keypirinha-steam/src/steam.py b/keypirinha-steam/src/steam.py
index c61189330649db05ff1d4d2857a48fb4083bade8..7df5fb99f1c7d8d7722002ba5594bd03d35157d2 100644
--- a/keypirinha-steam/src/steam.py
+++ b/keypirinha-steam/src/steam.py
@@ -99,10 +99,10 @@ class Steam(kp.Plugin):
         try:
             with open(librarylist_path) as fp:
                 library_data = acf.load(fp)
-            for key, library_root in library_data['LibraryFolders'].items():
+            for key, library_root in library_data['libraryfolders'].items():
                 if not key.isdigit():
                     continue
-                extra_library = os.path.join(library_root, 'steamapps')
+                extra_library = os.path.join(library_root['path'], 'steamapps')
                 library_list.append(extra_library)
         except Exception as e:
             self.warn('Failed to extract extra library paths: {}'.format(e))

```

Fixes #11 